### PR TITLE
ci(manual): rename workflow to 'exit-gate (manual-soft)'

### DIFF
--- a/.github/workflows/exit-gate-manual.yml
+++ b/.github/workflows/exit-gate-manual.yml
@@ -1,4 +1,4 @@
-name: exit-gate
+name: exit-gate (manual-soft)
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Rename manual workflow to distinguish from main exit-gate workflow