### PR TITLE
chore: ignore Makefile.tmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ DuRiCore/memory/phase11_traces/
 data/
 var/
 logs/
+
+# local tmp
+Makefile.tmp


### PR DESCRIPTION
Add Makefile.tmp to .gitignore to prevent untracked file warnings