### PR TITLE
chore: allow .wf_smoke in freeze-allow (prep)

### DIFF
--- a/.github/freeze-allow.txt
+++ b/.github/freeze-allow.txt
@@ -117,3 +117,5 @@ docs/ops/**
 prometheus.yml
 .github/workflows/temporal-relax-merge-v2.yml
 .github/workflows/protection-guard.yml
+
+.wf_smoke


### PR DESCRIPTION
enforce-freeze가 BASE allowlist를 참조하는 케이스 대비 선반영. PR #73의 .wf_smoke 파일 변경을 허용하기 위함.